### PR TITLE
Changing HTTP to HTTPS in embed-test.html

### DIFF
--- a/embed-test.html
+++ b/embed-test.html
@@ -10,10 +10,10 @@
     <h1>Testando o Embed</h1>
 
     <h2>Boleto ainda não gerado</h2>
-    <script src="http://localhost:5001/2/xxx.js"></script>
+    <script src="https://localhost:5001/2/xxx.js"></script>
 
     <h2>Boleto Avulso</h2>
-    <script src="http://localhost:5001/2/zp.js"></script>
+    <script src="https://localhost:5001/2/zp.js"></script>
 
     <h2>Boleto Fatura</h2>
     <div id="boleto-fatura"></div>
@@ -24,8 +24,8 @@
     <h2>Carnê Inteiro</h2>
     <div id="carne"></div>
 
-    <script src="http://localhost:5001/2/yj/carne.js?target=carne"></script>
-    <script src="http://localhost:5001/2/zp/letter.js?target=boleto-fatura"></script>
-    <script src="http://localhost:5001/2/yj/carne/2.js?target=boleto-parcela-2"></script>
+    <script src="https://localhost:5001/2/yj/carne.js?target=carne"></script>
+    <script src="https://localhost:5001/2/zp/letter.js?target=boleto-fatura"></script>
+    <script src="https://localhost:5001/2/yj/carne/2.js?target=boleto-parcela-2"></script>
   </body>
 </html>


### PR DESCRIPTION
There was a 'test file' that was linking for non-existing and 'not secure' (non HTTPS) files used as absolute links that make a "Insecure mixed content" log warning in deploy.
Changing this to avoid logging the problem again.